### PR TITLE
Add Strings for FSL-Related Intents and XFORM

### DIFF
--- a/JNIfTI_specification.md
+++ b/JNIfTI_specification.md
@@ -527,6 +527,15 @@ The below table maps the NIFTI data intent codes to the acceptable intent string
 |`NIFTI_INTENT_RGBA_VECTOR  `| `2004` |  `"rgba"`          |
 | **Each data point is a shape value**                 | | |
 |`NIFTI_INTENT_SHAPE        `| `2005` |  `"shape"`         |
+| **Used by FSL FNIRT**                 | | |
+|`NIFTI_INTENT_FSL_FNIRT_DISPLACEMENT_FIELD`| `2006` |  `"fsl_fnirt_displacement_field"`         |
+|`NIFTI_INTENT_FSL_CUBIC_SPLINE_COEFFICIENTS`| `2007` |  `"fsl_cubic_spline_coefficients"`         |
+|`NIFTI_INTENT_FSL_DCT_COEFFICIENTS`| `2008` |  `"fsl_dct_coefficients"`         |
+|`NIFTI_INTENT_FSL_QUADRATIC_SPLINE_COEFFICIENTS`| `2009` |  `"fsl_quadratic_spline_coefficients"`         |
+| **Used by FSL TOPUP**                 | | |
+|`NIFTI_INTENT_FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS`| `2016` |  `"fsl_topup_cubic_spline_coefficients"`         |
+|`NIFTI_INTENT_FSL_TOPUP_QUADRATIC_SPLINE_COEFFICIENTS`| `2017` |  `"fsl_topup_quadratic_spline_coefficients"`         |
+|`NIFTI_INTENT_FSL_TOPUP_FIELD`| `2018` |  `"fsl_topup_field"`         |
 
 
 #### SliceType (NIFTI-1 header: `slice_code`)

--- a/JNIfTI_specification.md
+++ b/JNIfTI_specification.md
@@ -561,6 +561,23 @@ The below table maps the NIFTI data slice codes to the acceptable slice strings.
 |  **Slice alternating decreasing type 2**             | | |
 |`NIFTI_SLICE_ALT_DEC2         `| `6` |  `"alt2-"`         |
 
+#### QForm/SForm (NIFTI-1 header: `qform_codes/sform_code`)
+
+
+|  NIFTI-1/2 XForm Code Name    |Code |JNIfTI QForm/SForm Key|
+|-------------------------------|-----|--------------------|
+|  **Arbitrary coordinates**                              | | |
+|`NIFTI_SLICE_UNKNOWN          `| `0` |  `""`              |
+|  **Scanner-based anatomical coordinates**        | | |
+|`NIFTI_XFORM_SCANNER_ANAT          `| `1` |  `"scanner_anat"`          |
+|  **Coordinates aligned to another file's, or to anatomical "truth"**  | | |
+|`NIFTI_XFORM_ALIGNED_ANAT          `| `2` |  `"aligned_anat"`          |
+|  **Coordinates aligned to Talairach-Tournoux Atlas**                    | | |
+|`NIFTI_XFORM_TALAIRACH          `| `3` |  `"talairach"`          |
+|  **MNI 152 normalized coordinates**                    | | |
+|`NIFTI_XFORM_MNI_152          `| `4` |  `"mni"`          |
+|  **Normalized coordinates(for any general standard template space)**             | | |
+|`NIFTI_XFORM_TEMPLATE_OTHER         `| `5` |  `"template_other"`         |
 
 #### NIIFormat (NIFTI-1 header: `magic`)
 

--- a/JNIfTI_specification.md
+++ b/JNIfTI_specification.md
@@ -527,15 +527,15 @@ The below table maps the NIFTI data intent codes to the acceptable intent string
 |`NIFTI_INTENT_RGBA_VECTOR  `| `2004` |  `"rgba"`          |
 | **Each data point is a shape value**                 | | |
 |`NIFTI_INTENT_SHAPE        `| `2005` |  `"shape"`         |
-| **Used by FSL FNIRT**                 | | |
-|`NIFTI_INTENT_FSL_FNIRT_DISPLACEMENT_FIELD`| `2006` |  `"fsl_fnirt_displacement_field"`         |
-|`NIFTI_INTENT_FSL_CUBIC_SPLINE_COEFFICIENTS`| `2007` |  `"fsl_cubic_spline_coefficients"`         |
-|`NIFTI_INTENT_FSL_DCT_COEFFICIENTS`| `2008` |  `"fsl_dct_coefficients"`         |
-|`NIFTI_INTENT_FSL_QUADRATIC_SPLINE_COEFFICIENTS`| `2009` |  `"fsl_quadratic_spline_coefficients"`         |
-| **Used by FSL TOPUP**                 | | |
-|`NIFTI_INTENT_FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS`| `2016` |  `"fsl_topup_cubic_spline_coefficients"`         |
-|`NIFTI_INTENT_FSL_TOPUP_QUADRATIC_SPLINE_COEFFICIENTS`| `2017` |  `"fsl_topup_quadratic_spline_coefficients"`         |
-|`NIFTI_INTENT_FSL_TOPUP_FIELD`| `2018` |  `"fsl_topup_field"`         |
+| **Used by FSL FNIRT**                                                                                     | | |
+|`NIFTI_INTENT_FSL_FNIRT_DISPLACEMENT_FIELD            ` | `2006` |  `"fsl_fnirt_displacement_field"`           |
+|`NIFTI_INTENT_FSL_CUBIC_SPLINE_COEFFICIENTS            `| `2007` |  `"fsl_cubic_spline_coefficients"`          |
+|`NIFTI_INTENT_FSL_DCT_COEFFICIENTS                     `| `2008` |  `"fsl_dct_coefficients"`                   |
+|`NIFTI_INTENT_FSL_QUADRATIC_SPLINE_COEFFICIENTS        `| `2009` |  `"fsl_quadratic_spline_coefficients"`      |
+| **Used by FSL TOPUP**                                                                                     | | |
+|`NIFTI_INTENT_FSL_TOPUP_CUBIC_SPLINE_COEFFICIENTS      `| `2016` |  `"fsl_topup_cubic_spline_coefficients"`    |
+|`NIFTI_INTENT_FSL_TOPUP_QUADRATIC_SPLINE_COEFFICIENTS  `| `2017` |  `"fsl_topup_quadratic_spline_coefficients"`|
+|`NIFTI_INTENT_FSL_TOPUP_FIELD                          `| `2018` |  `"fsl_topup_field"`                        |
 
 
 #### SliceType (NIFTI-1 header: `slice_code`)
@@ -564,20 +564,20 @@ The below table maps the NIFTI data slice codes to the acceptable slice strings.
 #### QForm/SForm (NIFTI-1 header: `qform_codes/sform_code`)
 
 
-|  NIFTI-1/2 XForm Code Name    |Code |JNIfTI QForm/SForm Key|
-|-------------------------------|-----|--------------------|
-|  **Arbitrary coordinates**                              | | |
-|`NIFTI_SLICE_UNKNOWN          `| `0` |  `""`              |
-|  **Scanner-based anatomical coordinates**        | | |
-|`NIFTI_XFORM_SCANNER_ANAT          `| `1` |  `"scanner_anat"`          |
+|  NIFTI-1/2 XForm Code Name    |Code |      JNIfTI QForm/SForm Key         |
+|-------------------------------|-----|-------------------------------------|
+|  **Arbitrary coordinates**                                            | | |
+|`NIFTI_SLICE_UNKNOWN          `| `0` |  `""`                               |
+|  **Scanner-based anatomical coordinates**                             | | |
+|`NIFTI_XFORM_SCANNER_ANAT     `| `1` |  `"scanner_anat"`                   |
 |  **Coordinates aligned to another file's, or to anatomical "truth"**  | | |
-|`NIFTI_XFORM_ALIGNED_ANAT          `| `2` |  `"aligned_anat"`          |
-|  **Coordinates aligned to Talairach-Tournoux Atlas**                    | | |
-|`NIFTI_XFORM_TALAIRACH          `| `3` |  `"talairach"`          |
-|  **MNI 152 normalized coordinates**                    | | |
-|`NIFTI_XFORM_MNI_152          `| `4` |  `"mni"`          |
-|  **Normalized coordinates(for any general standard template space)**             | | |
-|`NIFTI_XFORM_TEMPLATE_OTHER         `| `5` |  `"template_other"`         |
+|`NIFTI_XFORM_ALIGNED_ANAT     `| `2` |  `"aligned_anat"`                   |
+|  **Coordinates aligned to Talairach-Tournoux Atlas**                  | | |
+|`NIFTI_XFORM_TALAIRACH        `| `3` |  `"talairach"`                      |
+|  **MNI 152 normalized coordinates**                                   | | |
+|`NIFTI_XFORM_MNI_152          `| `4` |  `"mni_152"`                        |
+|  **Normalized coordinates(for any general standard template space)**  | | |
+|`NIFTI_XFORM_TEMPLATE_OTHER   `| `5` |  `"template_other"`                 |
 
 #### NIIFormat (NIFTI-1 header: `magic`)
 


### PR DESCRIPTION
[FSL Indent String](https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h#:~:text=/*!%20The%20following%20intent,define%20NIFTI_INTENT_FSL_TOPUP_FIELD%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%202018%0A%0A/*%20%40%7D%20*/)

FSL related intent values are missing in the definition. 

[XFORM](
https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h#:~:text=%5Cdefgroup%20NIFTI1_XFORM_CODES)

XFORMs are now as-is numeric values in json. For readability, they were now shown as strings like the other fields. 